### PR TITLE
save amount as float

### DIFF
--- a/ueberweisung/drinks.py
+++ b/ueberweisung/drinks.py
@@ -95,7 +95,7 @@ def load_recharges():
         if not tx.data['amount'].currency == "EUR":
             continue
         uid = match.group("uid")
-        amount = str(tx.data['amount'].amount)
+        amount = tx.data['amount'].amount
         tx_date = str(tx.data['date'])
         if uid not in recharges_by_uid:
             recharges_by_uid[uid] = []


### PR DESCRIPTION
There is maybe an issue with different locales while parsing str floats.

This slightly breaks drinks-scanner-display
https://github.com/flipdot/drinks-scanner-display/blob/master/drinks_scanner_display/users/sync.py#L62

`>>> Decimal(42.23)`
`Decimal('42.22999999999999687361196265555918216705322265625')`
