### PR TITLE
chore(deps): drop urllib3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ dependencies = [
   "tornado==6.5.1",
   "typing-extensions==4.9.0",
   "tzdata==2024.1",
-  "urllib3==1.26.19",
   "uwsgi==2.0.29",
   "webencodings==0.5.1",
   "werkzeug==3.0.6",

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,6 @@ dependencies = [
     { name = "tornado" },
     { name = "typing-extensions" },
     { name = "tzdata" },
-    { name = "urllib3" },
     { name = "uwsgi" },
     { name = "webencodings" },
     { name = "werkzeug" },
@@ -476,7 +475,6 @@ requires-dist = [
     { name = "tornado", specifier = "==6.5.1" },
     { name = "typing-extensions", specifier = "==4.9.0" },
     { name = "tzdata", specifier = "==2024.1" },
-    { name = "urllib3", specifier = "==1.26.19" },
     { name = "uwsgi", specifier = "==2.0.29" },
     { name = "webencodings", specifier = "==0.5.1" },
     { name = "werkzeug", specifier = "==3.0.6" },
@@ -752,11 +750,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "1.26.19"
+version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c8/93/65e479b023bbc46dab3e092bda6b0005424ea3217d711964ccdede3f9b1b/urllib3-1.26.19.tar.gz", hash = "sha256:3e3d753a8618b86d7de333b4223005f68720bcd6a7d2bcb9fbd2229ec7c1e429", size = 306068, upload-time = "2024-06-17T14:53:34.424Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/6a/99eaaeae8becaa17a29aeb334a18e5d582d873b6f084c11f02581b8d7f7f/urllib3-1.26.19-py2.py3-none-any.whl", hash = "sha256:37a0344459b199fce0e80b0d3569837ec6b6937435c5244e7fd73fa6006830f3", size = 143933, upload-time = "2024-06-17T14:53:31.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
I don't see `urllib3` imported anywhere, so I think we can remove it from the explicit dependency list and just have the transitive dependency from `requests`? :eyes: 

Closes https://github.com/flipdot/money-utils/pull/70